### PR TITLE
feat: add knowledge menu and permissions guard

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -54,13 +54,14 @@
 	import { getChannels, createNewChannel } from '$lib/apis/channels';
 	import ChannelModal from './Sidebar/ChannelModal.svelte';
 	import ChannelItem from './Sidebar/ChannelItem.svelte';
-	import PencilSquare from '../icons/PencilSquare.svelte';
-	import Search from '../icons/Search.svelte';
-	import SearchModal from './SearchModal.svelte';
-	import FolderModal from './Sidebar/Folders/FolderModal.svelte';
-	import Sidebar from '../icons/Sidebar.svelte';
-	import PinnedModelList from './Sidebar/PinnedModelList.svelte';
-	import Note from '../icons/Note.svelte';
+        import PencilSquare from '../icons/PencilSquare.svelte';
+        import Search from '../icons/Search.svelte';
+        import SearchModal from './SearchModal.svelte';
+        import FolderModal from './Sidebar/Folders/FolderModal.svelte';
+        import Sidebar from '../icons/Sidebar.svelte';
+        import PinnedModelList from './Sidebar/PinnedModelList.svelte';
+        import Note from '../icons/Note.svelte';
+        import BookOpen from '../icons/BookOpen.svelte';
 	import { slide } from 'svelte/transition';
 
 	const BREAKPOINT = 768;
@@ -548,32 +549,56 @@
 			</div>
 
 			<div>
-				<div class="">
-					<Tooltip content={$i18n.t('New Chat')} placement="right">
-						<a
-							class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
-							href="/"
-							draggable="false"
-							on:click={async (e) => {
-								e.stopImmediatePropagation();
-								e.preventDefault();
+                                <div class="">
+                                        <Tooltip content={$i18n.t('New Chat')} placement="right">
+                                                <a
+                                                        class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
+                                                        href="/"
+                                                        draggable="false"
+                                                        on:click={async (e) => {
+                                                                e.stopImmediatePropagation();
+                                                                e.preventDefault();
 
-								goto('/');
-								newChatHandler();
-							}}
-							aria-label={$i18n.t('New Chat')}
-						>
-							<div class=" self-center flex items-center justify-center size-9">
-								<PencilSquare className="size-4.5" />
-							</div>
-						</a>
-					</Tooltip>
-				</div>
+                                                                goto('/');
+                                                                newChatHandler();
+                                                        }}
+                                                        aria-label={$i18n.t('New Chat')}
+                                                >
+                                                        <div class=" self-center flex items-center justify-center size-9">
+                                                                <PencilSquare className="size-4.5" />
+                                                        </div>
+                                                </a>
+                                        </Tooltip>
+                                </div>
 
-				<div class="">
-					<Tooltip content={$i18n.t('Search')} placement="right">
-						<button
-							class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
+                                {#if $user?.role === 'admin' || $user?.permissions?.workspace?.knowledge}
+                                        <div class="">
+                                                <Tooltip content={$i18n.t('Knowledge Base')} placement="right">
+                                                        <a
+                                                                class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
+                                                                href="/knowledge"
+                                                                draggable="false"
+                                                                on:click={async (e) => {
+                                                                        e.stopImmediatePropagation();
+                                                                        e.preventDefault();
+
+                                                                        goto('/knowledge');
+                                                                        await itemClickHandler();
+                                                                }}
+                                                                aria-label={$i18n.t('Knowledge Base')}
+                                                        >
+                                                                <div class=" self-center flex items-center justify-center size-9">
+                                                                        <BookOpen className="size-4.5" />
+                                                                </div>
+                                                        </a>
+                                                </Tooltip>
+                                        </div>
+                                {/if}
+
+                                <div class="">
+                                        <Tooltip content={$i18n.t('Search')} placement="right">
+                                                <button
+                                                        class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
 							on:click={(e) => {
 								e.stopImmediatePropagation();
 								e.preventDefault();
@@ -746,11 +771,11 @@
 			</div>
 
 			<div class="pb-1.5">
-				<div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
-					<a
-						id="sidebar-new-chat-button"
-						class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
-						href="/"
+                                <div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
+                                        <a
+                                                id="sidebar-new-chat-button"
+                                                class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
+                                                href="/"
 						draggable="false"
 						on:click={newChatHandler}
 						aria-label={$i18n.t('New Chat')}
@@ -761,15 +786,39 @@
 
 						<div class="flex self-center translate-y-[0.5px]">
 							<div class=" self-center text-sm font-primary">{$i18n.t('New Chat')}</div>
-						</div>
-					</a>
-				</div>
+                                                </div>
+                                        </a>
+                                </div>
 
-				<div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
-					<button
-						class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
-						on:click={() => {
-							showSearch.set(true);
+                                {#if $user?.role === 'admin' || $user?.permissions?.workspace?.knowledge}
+                                        <div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
+                                                <a
+                                                        class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
+                                                        href="/knowledge"
+                                                        on:click={async (e) => {
+                                                                e.preventDefault();
+                                                                goto('/knowledge');
+                                                                await itemClickHandler();
+                                                        }}
+                                                        draggable="false"
+                                                        aria-label={$i18n.t('Knowledge Base')}
+                                                >
+                                                        <div class="self-center">
+                                                                <BookOpen className="size-4.5" />
+                                                        </div>
+
+                                                        <div class="flex self-center translate-y-[0.5px]">
+                                                                <div class=" self-center text-sm font-primary">{$i18n.t('Knowledge Base')}</div>
+                                                        </div>
+                                                </a>
+                                        </div>
+                                {/if}
+
+                                <div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
+                                        <button
+                                                class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
+                                                on:click={() => {
+                                                        showSearch.set(true);
 						}}
 						draggable="false"
 						aria-label={$i18n.t('Search')}

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -9,7 +9,7 @@
 	import { onMount, getContext } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { WEBUI_NAME, knowledge } from '$lib/stores';
+        import { WEBUI_NAME, knowledge } from '$lib/stores';
 	import {
 		getKnowledgeBases,
 		deleteKnowledgeById,
@@ -28,7 +28,9 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import XMark from '../icons/XMark.svelte';
 
-	let loaded = false;
+        export let basePath = '/workspace/knowledge';
+
+        let loaded = false;
 
 	let query = '';
 	let selectedItem = null;
@@ -133,13 +135,13 @@
 				<button
 					class=" px-2 py-2 rounded-xl hover:bg-gray-700/10 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition font-medium text-sm flex items-center space-x-1"
 					aria-label={$i18n.t('Create Knowledge')}
-					on:click={() => {
-						goto('/workspace/knowledge/create');
-					}}
-				>
-					<Plus className="size-3.5" />
-				</button>
-			</div>
+                                        on:click={() => {
+                                                goto(`${basePath}/create`);
+                                        }}
+                                >
+                                        <Plus className="size-3.5" />
+                                </button>
+                        </div>
 		</div>
 	</div>
 
@@ -155,10 +157,10 @@
 							)
 						);
 					} else {
-						goto(`/workspace/knowledge/${item.id}`);
-					}
-				}}
-			>
+                                                goto(`${basePath}/${item.id}`);
+                                        }
+                                }}
+                        >
 				<div class=" w-full">
 					<div class="flex items-center justify-between -mt-1">
 						{#if item?.meta?.document}

--- a/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
@@ -3,13 +3,15 @@
 	import { getContext } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { createNewKnowledge, getKnowledgeBases } from '$lib/apis/knowledge';
+        import { createNewKnowledge, getKnowledgeBases } from '$lib/apis/knowledge';
 	import { toast } from 'svelte-sonner';
 	import { knowledge, user } from '$lib/stores';
 	import AccessControl from '../common/AccessControl.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 
-	let loading = false;
+        export let basePath = '/workspace/knowledge';
+
+        let loading = false;
 
 	let name = '';
 	let description = '';
@@ -38,20 +40,20 @@
 		if (res) {
 			toast.success($i18n.t('Knowledge created successfully.'));
 			knowledge.set(await getKnowledgeBases(localStorage.token));
-			goto(`/workspace/knowledge/${res.id}`);
-		}
+                        goto(`${basePath}/${res.id}`);
+                }
 
-		loading = false;
-	};
+                loading = false;
+        };
 </script>
 
 <div class="w-full max-h-full">
-	<button
-		class="flex space-x-1"
-		on:click={() => {
-			goto('/workspace/knowledge');
-		}}
-	>
+        <button
+                class="flex space-x-1"
+                on:click={() => {
+                        goto(basePath);
+                }}
+        >
 		<div class=" self-center">
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -35,7 +35,7 @@
 	} from '$lib/apis/knowledge';
 	import { blobToFile } from '$lib/utils';
 
-	import Spinner from '$lib/components/common/Spinner.svelte';
+        import Spinner from '$lib/components/common/Spinner.svelte';
 	import Files from './KnowledgeBase/Files.svelte';
 	import AddFilesPlaceholder from '$lib/components/AddFilesPlaceholder.svelte';
 
@@ -68,7 +68,9 @@
 		files: any[];
 	};
 
-	let id = null;
+        export let basePath = '/workspace/knowledge';
+
+        let id = null;
 	let knowledge: Knowledge | null = null;
 	let query = '';
 
@@ -606,7 +608,7 @@
 		if (res) {
 			knowledge = res;
 		} else {
-			goto('/workspace/knowledge');
+                    goto(basePath);
 		}
 
 		const dropZone = document.querySelector('body');

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -1006,7 +1006,7 @@
 	"Name your knowledge base": "为您的知识库命名",
 	"Native": "原生",
 	"New Button": "新按钮",
-	"New Chat": "新对话",
+        "New Chat": "知识问答",
 	"New Folder": "创建分组",
 	"New Function": "新函数",
 	"New Note": "新笔记",

--- a/src/routes/(app)/knowledge/+layout.svelte
+++ b/src/routes/(app)/knowledge/+layout.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+        import { onMount, getContext } from 'svelte';
+        import { goto } from '$app/navigation';
+        import { WEBUI_NAME, showSidebar, user, mobile } from '$lib/stores';
+        import Tooltip from '$lib/components/common/Tooltip.svelte';
+        import Sidebar from '$lib/components/icons/Sidebar.svelte';
+
+        const i18n = getContext('i18n');
+
+        let hasAccess = false;
+        let initialized = false;
+
+        onMount(() => {
+                const unsubscribe = user.subscribe((value) => {
+                        if (value !== undefined) {
+                                const allowed =
+                                        value?.role === 'admin' || (value?.permissions?.workspace?.knowledge ?? false);
+
+                                if (!allowed) {
+                                        goto('/');
+                                } else {
+                                        hasAccess = true;
+                                }
+
+                                initialized = true;
+                        }
+                });
+
+                return () => {
+                        unsubscribe();
+                };
+        });
+</script>
+
+<svelte:head>
+        <title>
+                {$i18n.t('Knowledge Base')} • {$WEBUI_NAME}
+        </title>
+</svelte:head>
+
+{#if initialized && hasAccess}
+        <div
+                class=" relative flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
+                        ? 'md:max-w-[calc(100%-260px)]'
+                        : ''} max-w-full"
+        >
+                <nav class="   px-2.5 pt-1.5 backdrop-blur-xl drag-region">
+                        <div class=" flex items-center gap-1">
+                                {#if $mobile}
+                                        <div class="{$showSidebar ? 'md:hidden' : ''} self-center flex flex-none items-center">
+                                                <Tooltip
+                                                        content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+                                                        interactive={true}
+                                                >
+                                                        <button
+                                                                id="sidebar-toggle-button"
+                                                                class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition cursor-"
+                                                                on:click={() => {
+                                                                        showSidebar.set(!$showSidebar);
+                                                                }}
+                                                        >
+                                                                <div class=" self-center p-1.5">
+                                                                        <Sidebar />
+                                                                </div>
+                                                        </button>
+                                                </Tooltip>
+                                        </div>
+                                {/if}
+
+                                <div class="ml-2 py-0.5 self-center flex items-center">
+                                        <div
+                                                class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-medium bg-transparent py-1 touch-auto pointer-events-auto"
+                                        >
+                                                <a class="min-w-fit transition" href="/knowledge">
+                                                        {$i18n.t('Knowledge Base')}
+                                                </a>
+                                        </div>
+                                </div>
+                        </div>
+                </nav>
+
+                <div class="  pb-1 px-[18px] flex-1 max-h-full overflow-y-auto" id="knowledge-container">
+                        <slot />
+                </div>
+        </div>
+{/if}

--- a/src/routes/(app)/knowledge/+page.svelte
+++ b/src/routes/(app)/knowledge/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+        import { onMount } from 'svelte';
+        import { knowledge } from '$lib/stores';
+
+        import { getKnowledgeBases } from '$lib/apis/knowledge';
+        import Knowledge from '$lib/components/workspace/Knowledge.svelte';
+
+        onMount(async () => {
+                await Promise.all([
+                        (async () => {
+                                knowledge.set(await getKnowledgeBases(localStorage.token));
+                        })()
+                ]);
+        });
+</script>
+
+{#if $knowledge !== null}
+        <Knowledge basePath="/knowledge" />
+{/if}

--- a/src/routes/(app)/knowledge/[id]/+page.svelte
+++ b/src/routes/(app)/knowledge/[id]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+        import KnowledgeBase from '$lib/components/workspace/Knowledge/KnowledgeBase.svelte';
+</script>
+
+<KnowledgeBase basePath="/knowledge" />

--- a/src/routes/(app)/knowledge/create/+page.svelte
+++ b/src/routes/(app)/knowledge/create/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+        import CreateKnowledgeBase from '$lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte';
+</script>
+
+<CreateKnowledgeBase basePath="/knowledge" />

--- a/src/routes/(app)/notes/+page.svelte
+++ b/src/routes/(app)/notes/+page.svelte
@@ -1,20 +1,48 @@
 <script>
-	import { mobile, showArchivedChats, showSidebar, user } from '$lib/stores';
+        import { goto } from '$app/navigation';
+        import { onMount } from 'svelte';
+
+        import { mobile, showArchivedChats, showSidebar, user } from '$lib/stores';
 	import { getContext } from 'svelte';
 
 	const i18n = getContext('i18n');
 
 	import UserMenu from '$lib/components/layout/Sidebar/UserMenu.svelte';
 	import Notes from '$lib/components/notes/Notes.svelte';
-	import Tooltip from '$lib/components/common/Tooltip.svelte';
-	import Sidebar from '$lib/components/icons/Sidebar.svelte';
+        import Tooltip from '$lib/components/common/Tooltip.svelte';
+        import Sidebar from '$lib/components/icons/Sidebar.svelte';
+
+        let hasAccess = false;
+        let initialized = false;
+
+        onMount(() => {
+                const unsubscribe = user.subscribe((value) => {
+                        if (value !== undefined) {
+                                const allowed =
+                                        value?.role === 'admin' || (value?.permissions?.features?.notes ?? false);
+
+                                if (!allowed) {
+                                        goto('/');
+                                } else {
+                                        hasAccess = true;
+                                }
+
+                                initialized = true;
+                        }
+                });
+
+                return () => {
+                        unsubscribe();
+                };
+        });
 </script>
 
-<div
-	class=" flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
-		? 'md:max-w-[calc(100%-260px)]'
-		: ''} max-w-full"
->
+{#if initialized && hasAccess}
+        <div
+                class=" flex flex-col w-full h-screen max-h-[100dvh] transition-width duration-200 ease-in-out {$showSidebar
+                        ? 'md:max-w-[calc(100%-260px)]'
+                        : ''} max-w-full"
+        >
 	<nav class="   px-2 pt-1.5 backdrop-blur-xl w-full drag-region">
 		<div class=" flex items-center">
 			{#if $mobile}
@@ -84,4 +112,5 @@
 	<div class=" pb-1 flex-1 max-h-full overflow-y-auto @container">
 		<Notes />
 	</div>
-</div>
+        </div>
+{/if}


### PR DESCRIPTION
## Summary
- rename the sidebar new chat button to knowledge Q&A and surface a knowledge base menu entry with icon-only and expanded states
- allow knowledge management components to accept a base path and add standalone knowledge routes with a permission-aware layout
- guard the notes page behind feature permissions and adjust the Chinese translation for the new chat label

## Testing
- npm run lint *(fails: ESLint configuration requires eslint.config.js)*
- npm run lint:types *(fails: missing svelte-kit binary; lint:backend subsequently fails because pylint is unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68ca5ddb9110832e83213c4e1d9d5803