### PR TITLE
Hide non-admin sidebar shortcuts

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -2,7 +2,8 @@
 	import { toast } from 'svelte-sonner';
 	import { v4 as uuidv4 } from 'uuid';
 
-	import { goto } from '$app/navigation';
+        import { goto } from '$app/navigation';
+        import { page } from '$app/stores';
 	import {
 		user,
 		chats,
@@ -64,7 +65,11 @@
         import BookOpen from '../icons/BookOpen.svelte';
 	import { slide } from 'svelte/transition';
 
-	const BREAKPOINT = 768;
+        const BREAKPOINT = 768;
+
+        let isAdminPage = false;
+
+        $: isAdminPage = $page.url.pathname.startsWith('/admin');
 
 	let navElement;
 	let shiftKey = false;
@@ -595,27 +600,29 @@
                                         </div>
                                 {/if}
 
-                                <div class="">
-                                        <Tooltip content={$i18n.t('Search')} placement="right">
-                                                <button
-                                                        class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
-							on:click={(e) => {
-								e.stopImmediatePropagation();
-								e.preventDefault();
+                                {#if !isAdminPage}
+                                        <div class="">
+                                                <Tooltip content={$i18n.t('Search')} placement="right">
+                                                        <button
+                                                                class=" cursor-pointer flex rounded-lg hover:bg-gray-100 dark:hover:bg-gray-850 transition group"
+                                                                on:click={(e) => {
+                                                                        e.stopImmediatePropagation();
+                                                                        e.preventDefault();
 
-								showSearch.set(true);
-							}}
-							draggable="false"
-							aria-label={$i18n.t('Search')}
-						>
-							<div class=" self-center flex items-center justify-center size-9">
-								<Search className="size-4.5" />
-							</div>
-						</button>
-					</Tooltip>
-				</div>
+                                                                        showSearch.set(true);
+                                                                }}
+                                                                draggable="false"
+                                                                aria-label={$i18n.t('Search')}
+                                                        >
+                                                                <div class=" self-center flex items-center justify-center size-9">
+                                                                        <Search className="size-4.5" />
+                                                                </div>
+                                                        </button>
+                                                </Tooltip>
+                                        </div>
+                                {/if}
 
-				{#if ($config?.features?.enable_notes ?? false) && ($user?.role === 'admin' || ($user?.permissions?.features?.notes ?? true))}
+                                {#if !isAdminPage && ($config?.features?.enable_notes ?? false) && ($user?.role === 'admin' || ($user?.permissions?.features?.notes ?? true))}
 					<div class="">
 						<Tooltip content={$i18n.t('Notes')} placement="right">
 							<a
@@ -639,7 +646,7 @@
 					</div>
 				{/if}
 
-				{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools}
+                                {#if !isAdminPage && ($user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools)}
 					<div class="">
 						<Tooltip content={$i18n.t('Workspace')} placement="right">
 							<a
@@ -814,26 +821,28 @@
                                         </div>
                                 {/if}
 
-                                <div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
-                                        <button
-                                                class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
-                                                on:click={() => {
-                                                        showSearch.set(true);
-						}}
-						draggable="false"
-						aria-label={$i18n.t('Search')}
-					>
-						<div class="self-center">
-							<Search strokeWidth="2" className="size-4.5" />
-						</div>
+                                {#if !isAdminPage}
+                                        <div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
+                                                <button
+                                                        class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
+                                                        on:click={() => {
+                                                                showSearch.set(true);
+                                                        }}
+                                                        draggable="false"
+                                                        aria-label={$i18n.t('Search')}
+                                                >
+                                                        <div class="self-center">
+                                                                <Search strokeWidth="2" className="size-4.5" />
+                                                        </div>
 
-						<div class="flex self-center translate-y-[0.5px]">
-							<div class=" self-center text-sm font-primary">{$i18n.t('Search')}</div>
-						</div>
-					</button>
-				</div>
+                                                        <div class="flex self-center translate-y-[0.5px]">
+                                                                <div class=" self-center text-sm font-primary">{$i18n.t('Search')}</div>
+                                                        </div>
+                                                </button>
+                                        </div>
+                                {/if}
 
-				{#if ($config?.features?.enable_notes ?? false) && ($user?.role === 'admin' || ($user?.permissions?.features?.notes ?? true))}
+                                {#if !isAdminPage && ($config?.features?.enable_notes ?? false) && ($user?.role === 'admin' || ($user?.permissions?.features?.notes ?? true))}
 					<div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
 						<a
 							class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition"
@@ -853,7 +862,7 @@
 					</div>
 				{/if}
 
-				{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools}
+                                {#if !isAdminPage && ($user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools)}
 					<div class="px-[7px] flex justify-center text-gray-800 dark:text-gray-200">
 						<a
 							class="grow flex items-center space-x-3 rounded-lg px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-900 transition"


### PR DESCRIPTION
## Summary
- detect when the admin panel is active inside the shared sidebar
- hide the search, notes, and workspace shortcuts whenever the admin pages are open

## Testing
- npm run lint *(fails: eslint config missing; svelte-kit and pylint commands unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ca8d946cb8832e99c413178cdd6b82